### PR TITLE
Adding debug output for when handler.Handle returns with an err.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -47,10 +47,16 @@ func StartAgent(c *cli.Context) {
 		d.Decode(msg)
 
 		// For now... will need to add some throttling at some point.
-		go handler.Handle(msg)
+		go wrapHandler(handler.Handle, msg)
 	}
 
 	os.Exit(0)
+}
+
+func wrapHandler(handlerFunc func(*events.Message) error, msg *events.Message) {
+	if err := handlerFunc(msg); err != nil {
+		logrus.Debugf("Warning: %s", err)
+	}
 }
 
 func getDockerClient() (*client.Client, error) {


### PR DESCRIPTION
This is helpful for when a container start event is detected, but the secrets-bridge agent doesn't talk to the secrets-bridge server.  With this output the user will be able to see the reason for why the secrets-bridge agent skipped reacting to the event.
