### PR TITLE
Dont put // in path if k8s label path var not set

### DIFF
--- a/verifier/k8sResponse.go
+++ b/verifier/k8sResponse.go
@@ -39,6 +39,10 @@ func (rvr *RancherK8sVerifiedResponse) PrepareResponse(verified bool, container 
 }
 
 func (rvr *RancherK8sVerifiedResponse) Path() string {
+	if rvr.labelPath == "" {
+		return fmt.Sprintf("%s/%s/%s", rvr.environmentName, rvr.namespace, rvr.id)
+	}
+
 	return fmt.Sprintf("%s/%s/%s/%s", rvr.environmentName, rvr.namespace, rvr.labelPath, rvr.id)
 }
 


### PR DESCRIPTION
This results in a redirect from Vault, which probably isn't a good
idea to knowingly do.
